### PR TITLE
Making PSB wait for app to be deployed before reporting to site it is…

### DIFF
--- a/k8spsb/k8spsb.go
+++ b/k8spsb/k8spsb.go
@@ -609,7 +609,7 @@ func deployApp(w http.ResponseWriter, r *http.Request) *deployError {
 		rc.Labels["nazKind"] = "app"
 		rc.Spec = spec
 
-		_, err = kClient.CreateReplicationController(rc, false)
+		_, err = kClient.DeployReplicationController(appUniqueName, rc, false)
 		if err != nil {
 			return &deployError{httpStatusCode: http.StatusInternalServerError, message: err.Error()}
 		}


### PR DESCRIPTION
… ready

Before the change, PSB reported back to the app that it is ready once the replication controller has been created successfully.
This creates an issue since the site already publishes the new app url back to the hub and UI and getting a broken link
After the change the PSB is going to mark the app as fixed only when the container has been scheduled, pulled and started